### PR TITLE
added more spacing between widgets on about us page

### DIFF
--- a/src/pages/About_us.js
+++ b/src/pages/About_us.js
@@ -65,12 +65,12 @@ class About_us extends Component {
                         </div>
                         <div className="academic-widgets">
                             <div className="widget-row">
-                                <Widget image={Constants.Academic.Widget.Slack.icon} title={Constants.Community.Widget.Slack.body} body={Constants.Academic.Widget.Slack.body}></Widget>
-                                <Widget image={Constants.Academic.Widget.Exam.icon} title={Constants.Academic.Widget.Exam.title} body={Constants.Academic.Widget.Exam.body}></Widget>
+                                <Widget className="widget-item" image={Constants.Academic.Widget.Slack.icon} title={Constants.Community.Widget.Slack.body} body={Constants.Academic.Widget.Slack.body}></Widget>
+                                <Widget className="widget-item" image={Constants.Academic.Widget.Exam.icon} title={Constants.Academic.Widget.Exam.title} body={Constants.Academic.Widget.Exam.body}></Widget>
                             </div>
                             <div className="widget-row">
-                                <Widget image={Constants.Academic.Widget.Study.icon} title={Constants.Academic.Widget.Study.title} body={Constants.Academic.Widget.Study.body}></Widget>
-                                <Widget image={Constants.Academic.Widget.TA.icon} title={Constants.Academic.Widget.TA.title} body={Constants.Academic.Widget.TA.body}></Widget>
+                                <Widget className="widget-item" image={Constants.Academic.Widget.Study.icon} title={Constants.Academic.Widget.Study.title} body={Constants.Academic.Widget.Study.body}></Widget>
+                                <Widget className="widget-item" image={Constants.Academic.Widget.TA.icon} title={Constants.Academic.Widget.TA.title} body={Constants.Academic.Widget.TA.body}></Widget>
                             </div>
                         </div>
                     </div>

--- a/src/styles/about_us.css
+++ b/src/styles/about_us.css
@@ -128,8 +128,10 @@ body {
     justify-content: space-between;
     display: flex;
     flex-direction: row;
+    gap: 30px;
     flex-grow: 1;
 }
+
 
 .pillar-sections {
     display: flex;


### PR DESCRIPTION
<!-- if a section isn't applicable, feel free to delete it.-->

<!-- your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows" -->
- added more spacing between widgets on About Us Page to closer resemble FIgma design

## Context

<!-- what are you working on? -->
Worked on About Us Page. Making small tweaks to be closer to final design


## Changes Made

<!-- include details of what your changes actually are and how it is intended to work. -->
- added a gap of 30 pixels between the row items on the about us page under each pillar. Makes it easier to read and it's cleaner




## Screenshots (delete if not applicable)

<!-- this could include of screenshots of the new feature / proof that the changes work. -->

<details>

  <summary>Screen Shot Name</summary>
<img width="1300" alt="Screenshot 2023-09-15 at 8 44 43 AM" src="https://github.com/emarc0314/urmc-website/assets/37760008/2a779618-2dfd-4df0-806b-a1d130f0669f">


  <!-- insert file link here. Newlines above and below your link are necessary for this to work. -->


</details>